### PR TITLE
Directives for types

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -9,6 +9,7 @@ export interface IType {
   target: Function;
   fields: any[];
   implements?: Function;
+  directives?: IDirective[];
 }
 
 export interface IField {
@@ -32,17 +33,24 @@ interface IDirective {
 }
 
 interface ITypeArgs {
-  implements: Function;
+  implements?: Function;
+  directives?: IDirective[];
 }
 
 export const Type = (args?: ITypeArgs): ClassDecorator => (target: Function): void => {
+  let directives = [];
+  let implementsClass = undefined;
+
   if (types.some((e): boolean => e.target.name === target.name))
     throw new Error(`Error: Duplicate @Type ${target.name}`);
 
   const extendsClass = Reflect.getMetadata('extendedClass', target);
-  const implementsClass = args ? args.implements : undefined;
+  if (typeof args !== 'undefined') {
+    if (args.implements) implementsClass = args.implements;
+    if (args.directives) directives = args.directives;
+  }
 
-  types.push({ target, fields: [], implements: implementsClass || extendsClass });
+  types.push({ target, fields: [], implements: implementsClass || extendsClass, directives });
 };
 
 export const Input = (): ClassDecorator => (target: Function): void => {

--- a/src/generateTypeDefs.spec.ts
+++ b/src/generateTypeDefs.spec.ts
@@ -361,6 +361,38 @@ describe('Directives', (): void => {
       'type TestClass { author: String! @deprecated(reason: "use the authors array instead") authors: [String!]! }',
     );
   });
+
+  it('can handle a directive without params on types', async (): Promise<void> => {
+    @Type({ directives: [{ directive: 'deprecated' }] })
+    class TestClass {
+      @Field()
+      author: string;
+
+      @Field(String)
+      authors: string[];
+    }
+
+    expect(removeWhiteSpace(generateTypeDefs([TestClass]))).to.equal(
+      'type TestClass @deprecated { author: String! authors: [String!]! }',
+    );
+  });
+
+  it('can handle a directive with params on types', async (): Promise<void> => {
+    @Type({
+      directives: [{ directive: 'deprecated', reason: 'use the authors array instead' }],
+    })
+    class TestClass {
+      @Field()
+      author: string;
+
+      @Field(String)
+      authors: string[];
+    }
+
+    expect(removeWhiteSpace(generateTypeDefs([TestClass]))).to.equal(
+      'type TestClass @deprecated(reason: "use the authors array instead") { author: String! authors: [String!]! }',
+    );
+  });
 });
 
 @Type()

--- a/src/generateTypeDefs.ts
+++ b/src/generateTypeDefs.ts
@@ -39,33 +39,37 @@ export const generateTypeDefs = (klasses): string => {
   return typeDefs;
 };
 
+const generateDirectives = (directives): string => directives
+  .map((dir): string => {
+    const { directive, ...args } = dir;
+    const argsString = Object.keys(args).length
+      ? '(' +
+      Object.entries(args)
+        .map((a): string => {
+          return `${a[0]}: "${a[1]}"`;
+        })
+        .join(', ') +
+      ')'
+      : '';
+
+    return `@${directive}${argsString}`;
+  })
+  .join(' ');
+
 const generateTypeString = (type, typeName): string => {
   return `${typeName} ${type.target.name} ${
     type.implements ? 'implements ' + type.implements.name + ' ' : ''
-  }{\n${type.fields
-    .map((field): string => {
-      const nullable = `${field.nullable ? '' : '!'}`;
+    } ${
+    type.directives ? generateDirectives(type.directives) + ' ' : ''
+    }{\n${type.fields
+      .map((field): string => {
+        const nullable = `${field.nullable ? '' : '!'}`;
 
-      const directives = field.directives
-        .map((dir): string => {
-          const { directive, ...args } = dir;
-          const argsString = Object.keys(args).length
-            ? '(' +
-              Object.entries(args)
-                .map((a): string => {
-                  return `${a[0]}: "${a[1]}"`;
-                })
-                .join(', ') +
-              ')'
-            : '';
+        const directives = generateDirectives(field.directives);
 
-          return `@${directive}${argsString}`;
-        })
-        .join(' ');
-
-      return `  ${field.propertyKey}: ${field.type}${nullable} ${directives}`;
-    })
-    .join('\n')}\n}`;
+        return `  ${field.propertyKey}: ${field.type}${nullable} ${directives}`;
+      })
+      .join('\n')}\n}`;
 };
 
 const enrichTypes = (klasses, types, fields): IType[] => {


### PR DESCRIPTION
Hi Bram,
thanks for your typescript-typedefs package which is of great help. I am using it to generate the typeDefs for neo4j-graphql-js. This pull request adds the option to set directives for types as well because this is needed in neo4j-graphql-js when creating relationships with properties: [Neo4j-GraphQL-Docs](https://grandstack.io/docs/graphql-relationship-types.html#relationships-with-properties).

I hope, you are fine with the changes I made.