### PR TITLE
ability to handle object type, when decorator is used. 

### DIFF
--- a/src/generateTypeDefs.spec.ts
+++ b/src/generateTypeDefs.spec.ts
@@ -395,6 +395,40 @@ describe('Directives', (): void => {
   });
 });
 
+describe('Objects', (): void => {
+  beforeEach((): void => {
+    types.length = 0;
+    inputs.length = 0;
+    fields.length = 0;
+    interfaces.length = 0;
+  });
+  it('can handle union types', async (): Promise<void> => {
+    @Type()
+    class TestClass {
+      @Field({ type: Float, nullable: true })
+      testNumber: number | undefined;
+    }
+
+    expect(removeWhiteSpace(generateTypeDefs([TestClass]))).to.equal(
+      'type TestClass { testNumber: Float }',
+    );
+  });
+
+  // Object type occurs when the package is imported
+  it('can handle a value with Object type', async (): Promise<void> => {
+    @Type()
+    class TestClass {
+      @Field({ type: Int, nullable: true })
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      testNumber: Object;
+    }
+
+    expect(removeWhiteSpace(generateTypeDefs([TestClass]))).to.equal(
+      'type TestClass { testNumber: Int }',
+    );
+  });
+});
+
 @Type()
 export class Course {
   @Field()

--- a/src/generateTypeDefs.ts
+++ b/src/generateTypeDefs.ts
@@ -157,6 +157,8 @@ const getGraphqlTypeFromType = (type, passedType = undefined): GraphQLScalarType
       return GraphQLInt;
     case ID.prototype:
       return GraphQLID;
+    case Object.prototype:
+      if (passedType) return getGraphqlTypeFromType(passedType);
     default:
       return type.name;
   }


### PR DESCRIPTION
Hey Bram, 

We are running into the problem that your package cannot handle union types. This is a fix for this problem.
Please let me know if you agree, or would like to see a change.

Hope you are doing well,
Matthijs Breeman